### PR TITLE
Security: Override axios to 1.12.0 to fix DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,10 @@
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "overrides": {
+      "axios": "1.12.0"
+    }
   }
 }


### PR DESCRIPTION
# Security: Override axios to 1.12.0 to fix DoS vulnerability

## Summary
Adds a pnpm override to force all transitive axios dependencies to use version 1.12.0, which patches a DoS vulnerability due to lack of data size check identified by Dependabot.

axios is not a direct dependency in this project, but comes in transitively through:
- `@stellar/stellar-sdk` (was using axios 1.11.0)  
- `@dynamic-labs-wallet/core` (was using axios 1.9.0)

axios 1.12.0 is backward compatible with the previously used 1.x versions.

## Review & Testing Checklist for Human
- [ ] **Verify override works**: Check that `pnpm-lock.yaml` shows axios@1.12.0 after running `pnpm install`
- [ ] **Test app functionality**: Confirm the app builds and runs correctly with no runtime errors
- [ ] **Check for dependency conflicts**: Ensure no transitive dependencies break due to the forced axios version

### Notes
- The override forces ALL axios instances to 1.12.0, which should be safe given backward compatibility but needs verification
- Consider testing key user flows that might use the affected packages (@stellar/stellar-sdk, @dynamic-labs-wallet/core)

---
**Link to Devin run**: https://app.devin.ai/sessions/bf609251d888444a94f5721a1ad5292c  
**Requested by**: Penelope (@soinclined)