### PR TITLE
chore: remove bigint-buffer dependency to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
   },
   "pnpm": {
     "overrides": {
-      "axios": "1.12.0"
+      "axios": "1.12.0",
+      "@solana/web3.js": "^1.98.4",
+      "bigint-buffer": "npm:empty-npm-package@1.0.0"
+    },
+    "patchedDependencies": {
+      "@solana/buffer-layout-utils@0.2.0": "patches/@solana__buffer-layout-utils@0.2.0.patch"
     }
   }
 }

--- a/patches/@solana__buffer-layout-utils@0.2.0.patch
+++ b/patches/@solana__buffer-layout-utils@0.2.0.patch
@@ -1,0 +1,125 @@
+diff --git a/lib/cjs/bigint.js b/lib/cjs/bigint.js
+index 0462e8af7ae5fe2db34e4593d107dd04705dd858..05962ba302fc18d7ad0ff6a88d81bddc58c72c56 100644
+--- a/lib/cjs/bigint.js
++++ b/lib/cjs/bigint.js
+@@ -2,18 +2,49 @@
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.u256be = exports.u256 = exports.u192be = exports.u192 = exports.u128be = exports.u128 = exports.u64be = exports.u64 = exports.bigIntBE = exports.bigInt = void 0;
+ const buffer_layout_1 = require("@solana/buffer-layout");
+-const bigint_buffer_1 = require("bigint-buffer");
+ const base_1 = require("./base");
++function toBigIntLE(buffer) {
++    let result = 0n;
++    for (let i = 0; i < buffer.length; i++) {
++        result += BigInt(buffer[i]) << BigInt(8 * i);
++    }
++    return result;
++}
++function toBufferLE(bigint, length) {
++    const buffer = Buffer.alloc(length);
++    let value = bigint;
++    for (let i = 0; i < length; i++) {
++        buffer[i] = Number(value & 0xFFn);
++        value = value >> 8n;
++    }
++    return buffer;
++}
++function toBigIntBE(buffer) {
++    let result = 0n;
++    for (let i = 0; i < buffer.length; i++) {
++        result = (result << 8n) + BigInt(buffer[i]);
++    }
++    return result;
++}
++function toBufferBE(bigint, length) {
++    const buffer = Buffer.alloc(length);
++    let value = bigint;
++    for (let i = length - 1; i >= 0; i--) {
++        buffer[i] = Number(value & 0xFFn);
++        value = value >> 8n;
++    }
++    return buffer;
++}
+ const bigInt = (length) => (property) => {
+     const layout = (0, buffer_layout_1.blob)(length, property);
+     const { encode, decode } = (0, base_1.encodeDecode)(layout);
+     const bigIntLayout = layout;
+     bigIntLayout.decode = (buffer, offset) => {
+         const src = decode(buffer, offset);
+-        return (0, bigint_buffer_1.toBigIntLE)(Buffer.from(src));
++        return toBigIntLE(Buffer.from(src));
+     };
+     bigIntLayout.encode = (bigInt, buffer, offset) => {
+-        const src = (0, bigint_buffer_1.toBufferLE)(bigInt, length);
++        const src = toBufferLE(bigInt, length);
+         return encode(src, buffer, offset);
+     };
+     return bigIntLayout;
+@@ -25,10 +56,10 @@ const bigIntBE = (length) => (property) => {
+     const bigIntLayout = layout;
+     bigIntLayout.decode = (buffer, offset) => {
+         const src = decode(buffer, offset);
+-        return (0, bigint_buffer_1.toBigIntBE)(Buffer.from(src));
++        return toBigIntBE(Buffer.from(src));
+     };
+     bigIntLayout.encode = (bigInt, buffer, offset) => {
+-        const src = (0, bigint_buffer_1.toBufferBE)(bigInt, length);
++        const src = toBufferBE(bigInt, length);
+         return encode(src, buffer, offset);
+     };
+     return bigIntLayout;
+diff --git a/lib/esm/bigint.mjs b/lib/esm/bigint.mjs
+index 802bcc2e66d10cbf1e4a43ae600585d2cd966ed1..99606913b77e5befff6fd91ba32d70eb4277417b 100644
+--- a/lib/esm/bigint.mjs
++++ b/lib/esm/bigint.mjs
+@@ -1,6 +1,37 @@
+ import { blob } from '@solana/buffer-layout';
+-import { toBigIntBE, toBigIntLE, toBufferBE, toBufferLE } from 'bigint-buffer';
+ import { encodeDecode } from './base.mjs';
++function toBigIntLE(buffer) {
++    let result = 0n;
++    for (let i = 0; i < buffer.length; i++) {
++        result += BigInt(buffer[i]) << BigInt(8 * i);
++    }
++    return result;
++}
++function toBufferLE(bigint, length) {
++    const buffer = Buffer.alloc(length);
++    let value = bigint;
++    for (let i = 0; i < length; i++) {
++        buffer[i] = Number(value & 0xFFn);
++        value = value >> 8n;
++    }
++    return buffer;
++}
++function toBigIntBE(buffer) {
++    let result = 0n;
++    for (let i = 0; i < buffer.length; i++) {
++        result = (result << 8n) + BigInt(buffer[i]);
++    }
++    return result;
++}
++function toBufferBE(bigint, length) {
++    const buffer = Buffer.alloc(length);
++    let value = bigint;
++    for (let i = length - 1; i >= 0; i--) {
++        buffer[i] = Number(value & 0xFFn);
++        value = value >> 8n;
++    }
++    return buffer;
++}
+ export const bigInt = (length) => (property) => {
+     const layout = blob(length, property);
+     const { encode, decode } = encodeDecode(layout);
+diff --git a/package.json b/package.json
+index b91cc43799f36eeedcbd26fdb4862c21cc399883..47d579406e2cda1698f6974df1c8971529f30fe7 100644
+--- a/package.json
++++ b/package.json
+@@ -40,7 +40,6 @@
+     "dependencies": {
+         "@solana/buffer-layout": "^4.0.0",
+         "@solana/web3.js": "^1.32.0",
+-        "bigint-buffer": "^1.1.5",
+         "bignumber.js": "^9.0.1"
+     },
+     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios: 1.12.0
+  '@solana/web3.js': ^1.98.4
+  bigint-buffer: npm:empty-npm-package@1.0.0
+
+patchedDependencies:
+  '@solana/buffer-layout-utils@0.2.0':
+    hash: p54ccjrnoekjpuyghrf6g2rx4e
+    path: patches/@solana__buffer-layout-utils@0.2.0.patch
+
 importers:
 
   .:
@@ -1726,22 +1736,22 @@ packages:
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/web3.js': ^1.95.3
+      '@solana/web3.js': ^1.98.4
 
   '@solana/spl-token-metadata@0.1.6':
     resolution: {integrity: sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/web3.js': ^1.95.3
+      '@solana/web3.js': ^1.98.4
 
   '@solana/spl-token@0.4.12':
     resolution: {integrity: sha512-K6CxzSoO1vC+WBys25zlSDaW0w4UFZO/IvEZquEI35A/PjqXNQHeVigmDCZYEJfESvYarKwsr8tYr/29lPtvaw==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/web3.js': ^1.95.5
+      '@solana/web3.js': ^1.98.4
 
-  '@solana/web3.js@1.98.1':
-    resolution: {integrity: sha512-gRAq1YPbfSDAbmho4kY7P/8iLIjMWXAzBJdP9iENFR+dFQSBSueHzjK/ou8fxhqHP9j+J4Msl4p/oDemFcIjlg==}
+  '@solana/web3.js@1.98.4':
+    resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
   '@spruceid/siwe-parser@2.1.2':
     resolution: {integrity: sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==}
@@ -2211,11 +2221,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
-
-  axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+  axios@1.12.0:
+    resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
 
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -2263,15 +2270,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  bigint-buffer@1.1.5:
-    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
-    engines: {node: '>= 10.0.0'}
-
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -2692,6 +2692,9 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  empty-npm-package@1.0.0:
+    resolution: {integrity: sha512-q4Mq/+XO7UNDdMiPpR/LIBIW1Zl4V0Z6UT9aKGqIAnBCtCb3lvZJM1KbDbdzdC8fKflwflModfjR29Nt0EpcwA==}
+
   encode-utf8@1.0.3:
     resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
 
@@ -2866,9 +2869,6 @@ packages:
 
   feaxios@0.0.23:
     resolution: {integrity: sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -5988,7 +5988,7 @@ snapshots:
       '@ethersproject/transactions': 5.7.0
       '@farcaster/auth-kit': 0.6.0(@types/react@19.1.1)(babel-plugin-macros@3.1.0)(bufferutil@4.0.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(utf-8-validate@5.0.10)(viem@2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))
       '@mysten/sui': 1.24.0(typescript@5.8.3)
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       bs58: 5.0.0
       clsx: 2.1.1
       color: 4.2.3
@@ -6058,7 +6058,7 @@ snapshots:
 
   '@crossmint/common-sdk-base@0.9.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       bs58: 5.0.0
       tweetnacl: 1.0.3
       viem: 2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -6071,7 +6071,7 @@ snapshots:
 
   '@crossmint/common-sdk-base@0.9.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       bs58: 5.0.0
       tweetnacl: 1.0.3
       viem: 2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -6088,7 +6088,7 @@ snapshots:
       '@crossmint/client-signers': 0.0.18
       '@crossmint/common-sdk-base': 0.9.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@hey-api/client-fetch': 0.8.1
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@stellar/stellar-sdk': 14.0.0-rc.3
       abitype: 1.0.8(typescript@5.8.3)(zod@3.22.4)
       bs58: 5.0.0
@@ -6109,7 +6109,7 @@ snapshots:
       '@crossmint/client-signers': 0.0.18
       '@crossmint/common-sdk-base': 0.9.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@hey-api/client-fetch': 0.8.1
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@stellar/stellar-sdk': 14.0.0-rc.3
       abitype: 1.0.8(typescript@5.8.3)(zod@3.22.4)
       bs58: 5.0.0
@@ -6149,7 +6149,7 @@ snapshots:
 
   '@dynamic-labs-wallet/core@0.0.124':
     dependencies:
-      axios: 1.9.0
+      axios: 1.12.0
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
@@ -6202,7 +6202,7 @@ snapshots:
       '@dynamic-labs/wallet-book': 4.25.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@dynamic-labs/wallet-connector-core': 4.25.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@dynamic-labs/webauthn': 4.25.6
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@turnkey/iframe-stamper': 2.0.0
       '@turnkey/solana': 1.0.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.1)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@turnkey/webauthn-stamper': 0.5.0
@@ -6400,8 +6400,8 @@ snapshots:
       '@dynamic-labs/utils': 4.25.6
       '@dynamic-labs/wallet-book': 4.25.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@dynamic-labs/wallet-connector-core': 4.25.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@solana/spl-token': 0.4.12(@solana/web3.js@1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/spl-token': 0.4.12(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       eventemitter3: 5.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -6425,7 +6425,7 @@ snapshots:
       '@dynamic-labs/waas-svm': 4.25.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))
       '@dynamic-labs/wallet-book': 4.25.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@dynamic-labs/wallet-connector-core': 4.25.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@wallet-standard/app': 1.0.1
       '@wallet-standard/base': 1.0.1
       '@wallet-standard/experimental-features': 0.1.1
@@ -6588,7 +6588,7 @@ snapshots:
       '@dynamic-labs/utils': 4.25.6
       '@dynamic-labs/waas': 4.25.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4))
       '@dynamic-labs/wallet-connector-core': 4.25.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       bs58: 5.0.0
       eventemitter3: 5.0.1
     transitivePeerDependencies:
@@ -7729,11 +7729,11 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@solana/buffer-layout-utils@0.2.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@solana/buffer-layout-utils@0.2.0(patch_hash=p54ccjrnoekjpuyghrf6g2rx4e)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/buffer-layout': 4.0.1
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      bigint-buffer: 1.1.5
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      bigint-buffer: empty-npm-package@1.0.0
       bignumber.js: 9.3.1
     transitivePeerDependencies:
       - bufferutil
@@ -7816,29 +7816,29 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
     dependencies:
       '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
     dependencies:
       '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@solana/spl-token@0.4.12(@solana/web3.js@1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@solana/spl-token@0.4.12(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/buffer-layout': 4.0.1
-      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/buffer-layout-utils': 0.2.0(patch_hash=p54ccjrnoekjpuyghrf6g2rx4e)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       buffer: 6.0.3
     transitivePeerDependencies:
       - bufferutil
@@ -7847,7 +7847,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@solana/web3.js@1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@noble/curves': 1.9.4
@@ -7904,7 +7904,7 @@ snapshots:
   '@stellar/stellar-sdk@14.0.0-rc.3':
     dependencies:
       '@stellar/stellar-base': 14.0.0-rc.2
-      axios: 1.11.0
+      axios: 1.12.0
       bignumber.js: 9.3.1
       eventsource: 2.0.2
       feaxios: 0.0.23
@@ -8064,7 +8064,7 @@ snapshots:
 
   '@turnkey/solana@1.0.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.1)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@turnkey/http': 2.15.0
       '@turnkey/sdk-browser': 1.8.0(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.1)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)
       '@turnkey/sdk-server': 1.5.0
@@ -8691,15 +8691,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.11.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.9.0:
+  axios@1.12.0:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.4
@@ -8761,15 +8753,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bigint-buffer@1.1.5:
-    dependencies:
-      bindings: 1.5.0
-
   bignumber.js@9.3.1: {}
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   bl@4.1.0:
     dependencies:
@@ -9183,6 +9167,8 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  empty-npm-package@1.0.0: {}
+
   encode-utf8@1.0.3: {}
 
   encodeurl@1.0.2: {}
@@ -9356,8 +9342,6 @@ snapshots:
   feaxios@0.0.23:
     dependencies:
       is-retry-allowed: 3.0.0
-
-  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -10987,7 +10971,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.1
       uuid: 8.3.2
-      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10


### PR DESCRIPTION
# Remove bigint-buffer dependency to fix security vulnerability

## Summary
Removes the `bigint-buffer` dependency to address a HIGH severity buffer overflow vulnerability (CVE affecting versions ≤ 1.1.5). Since `bigint-buffer` was only used as a transitive dependency through `@solana/buffer-layout-utils` (an archived package), this PR implements:

1. **Upgraded `@solana/web3.js`** to v1.98.4+ (which no longer depends on bigint-buffer)
2. **Created a pnpm patch** for `@solana/buffer-layout-utils@0.2.0` that replaces bigint-buffer with native JavaScript BigInt implementations  
3. **Used pnpm overrides** to block bigint-buffer installation entirely

The patch replaces four critical functions (`toBigIntLE`, `toBufferLE`, `toBigIntBE`, `toBufferBE`) with hand-written BigInt implementations that provide equivalent functionality for blockchain binary data operations.

## Review & Testing Checklist for Human
**HIGH RISK** - 5 critical items to verify:

- [ ] **Verify BigInt conversion math is correct** - Review the patch file implementations for `toBigIntLE`, `toBufferLE`, `toBigIntBE`, `toBufferBE` functions. These handle endianness conversion and bit shifting which is critical for Solana operations
- [ ] **Test core Solana/wallet functionality end-to-end** - Verify wallet creation, transaction signing, and any blockchain operations work correctly with the new BigInt implementations  
- [ ] **Confirm bigint-buffer is completely removed** - Search `node_modules` and `pnpm-lock.yaml` to ensure no references to `bigint-buffer@1.1.5` remain
- [ ] **Test application startup and basic UI flows** - Ensure no runtime errors from the dependency changes and that the app functions normally
- [ ] **Verify patch persistence** - Confirm the pnpm patch will be applied correctly in production builds and won't be lost during future dependency updates

### Notes
- The `@solana/buffer-layout-utils` package is archived/read-only, so pnpm patching was the only viable solution
- This same fix needs to be applied to `stellar-server-wallets` and `my-own-fintech` repositories  
- Session requested by Penelope (@soinclined): https://app.devin.ai/sessions/65d3e8006fc94200836c2612732193ff